### PR TITLE
Fixing escape characters following RFC6901 (Json Pointer)

### DIFF
--- a/src/clj_json_patch/util.clj
+++ b/src/clj_json_patch/util.clj
@@ -76,7 +76,7 @@
                                 "'. Consider adding a more explicit data "
                                 "structure as a child of an existing object."))))
       (cond (map? obj)
-            (assoc obj (second (first segs)) val)
+            (assoc obj (eval-escape-characters (second (first segs))) val)
             (vector? obj)
             (let [idx (Integer/parseInt (second (re-find #"/(\d+)" path)))]
               (try

--- a/test/clj_json_patch/core_test.clj
+++ b/test/clj_json_patch/core_test.clj
@@ -219,7 +219,10 @@
          (fact "first nested object updated correctly"
                (get (first (get patched "k1")) "s0k1") => "new value")
          (fact "second nested object unchanged"
-               (get (second (get patched "k1")) "s1k1") => "s1v1")))
+               (get (second (get patched "k1")) "s1k1") => "s1v1"))
+       (fact "Patch with escape characters"
+             (patch {"foo" {"bar" 42}}
+                    [{"op" "add", "path" "/foo/baz~1bar", "value" "ohyeah"}]) => {"foo" {"bar" 42 "baz/bar" "ohyeah"}}))
 
 (facts "Nested JSON patch"
        (let [obj1 {"nested" {"foo" "bar"}}

--- a/test/clj_json_patch/util_test.clj
+++ b/test/clj_json_patch/util_test.clj
@@ -8,7 +8,8 @@
       obj3 {"foo" {"bar" {"baz" "deep!"}}}
       obj4 ["foo" "bar"]
       obj5 {"foo" ["bar" "baz" "last"]}
-      obj6 {"foo" {"bar" ["baz" "deeper!"]}}]
+      obj6 {"foo" {"bar" ["baz" "deeper!"]}}
+      obj7 {"foo/bar" "baz"}]
   (facts "get-patch-value"
          (fact "get value from simple map"
                (get-patch-value obj1 "/foo") => "bar")
@@ -21,7 +22,9 @@
          (fact "get value from simple map of array"
                (get-patch-value obj5 "/foo/1") => "baz")
          (fact "get value from map of map with array"
-               (get-patch-value obj6 "/foo/bar/1") => "deeper!"))
+               (get-patch-value obj6 "/foo/bar/1") => "deeper!")
+         (fact "escape / with ~1"
+               (get-patch-value obj7 "/foo~1bar") => "baz"))
   (facts "get-value-path"
          (fact "get path from simple map"
                (get-value-path obj1 "bar") => "/foo")
@@ -34,7 +37,13 @@
          (fact "get path from simple map of array"
                (get-value-path obj5 "baz") => "/foo/1")
          (fact "get path from map of map with array"
-               (get-value-path obj6 "deeper!") => "/foo/bar/1")))
+               (get-value-path obj6 "deeper!") => "/foo/bar/1")
+         (fact "get path from key with /"
+               (get-value-path obj7 "baz") => "/foo~1bar")))
+
+(facts "escaping characters"
+       (fact "must not depend on ordering"
+             (eval-escape-characters "~01") => "~1"))
 
 (facts "diff-vecs"
        (let [v1 ["all" "grass" "cows" "eat"]


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6901
Some objects may use `/` and `~` as part of map's key, RFC6901 says:
```
Because the characters '~' (%x7E) and '/' (%x2F) have special
   meanings in JSON Pointer, '~' needs to be encoded as '~0' and '/'
   needs to be encoded as '~1' when these characters appear in a
   reference token.
```

As stated on Appendix of Json Patch RFC, escape ordering.
https://tools.ietf.org/html/rfc6902#appendix-A.14