### PR TITLE
Improve vector diffing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JSON Pointer https://tools.ietf.org/html/rfc6901
 Usage
 -----
 ```clojure
-[clj-json-patch 0.1.7]
+[clj-json-patch 0.1.8]
 
 ;; From some example namespace:
 (ns example.namespace

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main clj-json-patch.core
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [cheshire "5.8.0"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [cheshire "5.12.0"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :profiles {:dev {:dependencies [[midje/midje "1.9.5"]]
-                   :plugins [[lein-midje "3.2.1"]]}})
+  :profiles {:dev {:dependencies [[midje/midje "1.10.9"]]
+                   :plugins      [[lein-midje "3.2.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-json-patch "0.1.7"
+(defproject clj-json-patch "0.1.8"
   :description "Clojure implementation of http://tools.ietf.org/html/rfc6902"
   :url "http://github.com/daviddpark/clj-json-patch"
   :license {:name "Eclipse Public License"

--- a/test/clj_json_patch/core_test.clj
+++ b/test/clj_json_patch/core_test.clj
@@ -25,6 +25,12 @@
              patches [{"op" "add" "path" "/foo/0" "value" "qux"}]]
          (fact "Adding an Array Element"
                (diff obj1 obj2) => patches))
+       (let [obj1 {"foo" []}
+             obj2 {"foo" ["bar" "baz"]}
+             patches [{"op" "add" "path" "/foo/0" "value" "bar"}
+                      {"op" "add" "path" "/foo/1" "value" "baz"}]]
+         (fact "Adding two Array Elements"
+               (diff obj1 obj2) => patches))
        (let [obj1 {"foo" ["bar" "baz"]}
              obj2 {"foo" ["bar" "qux" "baz"]}
              patches [{"op" "add" "path" "/foo/1" "value" "qux"}]]


### PR DESCRIPTION
This PR aims to primarily fix the following incorrect output reported by `diff-vecs`:

```
       (let [obj1 {"foo" []}
             obj2 {"foo" ["bar" "baz"]}
             patches [{"op" "add" "path" "/foo/0" "value" "bar"}
                      {"op" "add" "path" "/foo/1" "value" "baz"}]]
         (fact "Adding two Array Elements"
               (diff obj1 obj2) => patches))
=> 

FAIL JSON diff - Adding two Array Elements at (core_test.clj:33)
Expected:
[{"op" "add" "path" "/foo/0" "value" "bar"}
 {"op" "add" "path" "/foo/1" "value" "baz"}]
Actual:
[{"op" "replace" "path" "/foo/0" "value" "bar"}
 {"op" "add" "path" "/foo/1" "value" "baz"}]
```

Additionally, the `diff-vecs` implementation is slightly changed to improve performance for the likely common case of diff'ed vectors being the same or sharing common prefixes / suffixes. 

If any changes to this PR are desired, please feel free to suggest them or just pick from this PR whatever changes you deem desirable.
